### PR TITLE
Update auto-reply regex. #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@
 const isTesting = true;
 const token = isTesting ? "cog" : "cap";
 
+// Uncomment to test regex only.
+//require("./messageEvents/autoreply.js"); throw new Error(); // Error to abort after printing/testing regex.
+
 //constants
 const Discord = require("discord.js");
 const client = new Discord.Client();

--- a/messageEvents/autoreply.js
+++ b/messageEvents/autoreply.js
@@ -5,46 +5,52 @@ const volcanoidsServerId = "444244464903651348";
 const discussOtherGamesChannelId = "496325967883534337";
 const faqChannelId = "454972890299891723";
 
-module.exports.run = async (client, message, isTesting) => {
-    // Emoji
-    const thumbsUpId_cogHand = "713469848193073303"; // :cogLike:
-    const thumbsUpId_testing = "545279802198851615"; // :kappa:
-    const thumbsUpId = isTesting ? thumbsUpId_testing : thumbsUpId_cogHand;
+// Emoji
+const thumbsUpId_cogHand = "713469848193073303"; // :cogLike:
+const thumbsUpId_testing = "545279802198851615"; // :kappa:
 
-    const thumbsDownId_cogHand = "722120016723574805"; // :cogThumbsDown:
-    const thumbsDownId_testing = "546734308161749011"; // :Shotgun:
+const thumbsDownId_cogHand = "722120016723574805"; // :cogThumbsDown:
+const thumbsDownId_testing = "546734308161749011"; // :Shotgun:
+
+// Don't put these in a repeated function. They do not need to be recreated every time we run it.
+// This needs to be called in a static context when the file inits so we don't have to recreate the regex every time we parse a message.
+
+const consolePart1 = `(will|game|to|available)`;
+const consolePart2 = `(console|xbox|ps4|ps5|playstation)`; // The target.
+const consoleAutoreplyRegex = CreateAutoReplyRegex([
+    `${consolePart2}.*${consolePart1}`,
+    `${consolePart1}.*${consolePart2}`
+], `igm`);
+
+// A var since I keep copying the "the game", "it", "this", etc in many of these.
+
+const theGamePart1 = `(that|the|this)`; // The 'the' part of 'the game'. The group of words that patch the first part.
+const theGamePart2 = `(game|it|volcanoid(s?))`; // The 'game' part of 'the game'. The group of words that patch the last part.
+
+// Merge so we either match: The first part, the second part, or both parts.
+// e.g. we match: 'the', 'the game', or 'game'.
+// Breakdown:               'the'     |     'game'    |            'the game'
+const theGameRegex = `(${theGamePart1}|${theGamePart2}|${theGamePart1}\\s${theGamePart2})`;
+
+const steamAutoreplyRegex = CreateAutoReplyRegex([
+    `when(('|’)s|s| is)?(\\s${theGameRegex})? (come|coming) out`,
+    `is(\\s${theGameRegex}) (out|released|available)( yet)?`,
+    `(where|how) (can|do).*?(get|buy|play)\\s.*?${theGameRegex}`,
+    `(where|how).*?download`,
+    `(is|if|will)( [^ \\n]+?)?\\s${theGameRegex}( (?!only)[^ \\n]+?)? (free|on steam)`,
+    `what.*?(get|buy|is)\\s.*?${theGameRegex}?( [^ \\n]+?)? on(\\s|\\?|\\.)`,
+    `how much\\s.*?${theGameRegex}? cost`,
+    `how (much|many)( [^ \\n]+?)? is\\s${theGameRegex}`,
+    `can i play( [^ \\n]+?)?(\\s${theGameRegex})? now`,
+    `price in (usd|dollars|aud|cad)`
+], `igm`);
+
+module.exports.run = async (client, message, isTesting) => {
+    const thumbsUpId = isTesting ? thumbsUpId_testing : thumbsUpId_cogHand;
     const thumbsDownId = isTesting ? thumbsDownId_testing : thumbsDownId_cogHand;
 
-    // Init some global vars so we don't have to do this on each command.
-    thumbsUp = client.emojis.cache.get(thumbsUpId);
-    thumbsDown = client.emojis.cache.get(thumbsDownId);
-
-    let consoleAutoreplyRegex = CreateAutoReplyRegex([
-        `console.*(will|game|to|available)`,
-        `(will|game|to|available).*console`,
-        `xbox.*(will|game|to|available)`,
-        `(will|game|to|available).*xbox`,
-        `(ps4|ps5).*(will|game|to|available)`,
-        `(will|game|to|available).*(ps4|ps5|playstation)`
-    ],
-        `igm`);
-
-    // A var since I keep copying the "the game", "it", "this", etc in many of these.
-    const theGameRegex = `( (that|the|this))?( (game|it|volcanoid(s?)))?`;
-    let steamAutoreplyRegex = CreateAutoReplyRegex([
-        `when(('|’)s|s| is)?${theGameRegex} (come|coming) out`,
-        `is${theGameRegex} (out|released|available)( yet)?`,
-        `(where|how) (can|do).*?(get|buy|play).*?${theGameRegex}`,
-        `(where|how).*?download`,
-        `(is|if|will)( [^ \\n]+?)?${theGameRegex}( (?!only)[^ \\n]+?)? (free|on steam)`,
-        `what.*?(get|buy|is).*?${theGameRegex}( [^ \\n]+?)? on`,
-        `how much.*?${theGameRegex} cost`,
-        `how (much|many)( [^ \\n]+?)? is${theGameRegex}`,
-        `can i play( [^ \\n]+?)?${theGameRegex} now`,
-        `price in (usd|dollars|aud|cad)`
-    ],
-        `igm`);
-
+    const thumbsUp = client.emojis.cache.get(thumbsUpId);
+    const thumbsDown = client.emojis.cache.get(thumbsDownId);
 
     // Autoreply (If running as cogbot or on the Volcanoids server. Ignoring discuss-other-games.)
     if ((isTesting || message.guild.id == volcanoidsServerId) && message.channel.id !== discussOtherGamesChannelId) {
@@ -55,18 +61,19 @@ module.exports.run = async (client, message, isTesting) => {
             CreateAutoReply(message.channel, `You can get Volcanoids on Steam here: https://store.steampowered.com/app/951440/Volcanoids/`, true /* Include check FAQ text. */);
         }
     }
-
 }
 
 /**
  * Pass an array of individual regex to match. This will merge them into one pattern.
+ * LEAVE AS A FUNCTION. NOT A VARIABLE. This needs to be called in a static context when the file inits so we don't have to recreate the regex every time we parse a message.
+ * Also needs to be a func so we can run it without running the Discord bot at all.
  *
  * @param individualLinesToMatch Patterns to merge.
  * @param flags                  (Optional) Regex flags to use.
  * @param ignoreQuotedText       (Optional) Makes sure each individual pattern ignores lines that start with `>`.
  * @param ignoreCodeText         (Optional) Makes sure each individual pattern ignores matches surrounded with `. (Currently broken.)
  */
-const CreateAutoReplyRegex = (individualLinesToMatch, flags = "", ignoreQuotedText = true, ignoreCodeText = true) => {
+function CreateAutoReplyRegex(individualLinesToMatch, flags = "", ignoreQuotedText = true, ignoreCodeText = true) {
     let regexStr = ``;
 
     individualLinesToMatch.forEach((line, index) => {
@@ -78,10 +85,12 @@ const CreateAutoReplyRegex = (individualLinesToMatch, flags = "", ignoreQuotedTe
 
         if (ignoreQuotedText === true) toMatch = `^(?!>).*?${toMatch}`;
 
+        //console.log(`Adding: ${toMatch}`);
+
         regexStr += `(${toMatch})`
     });
 
-    //console.log(`Made Regex: ${regexStr}`);
+    //console.log(`\nMade Regex: ${regexStr}\n`);
 
     return RegExp(regexStr, flags);
 }


### PR DESCRIPTION
- Updated the steam auto-reply to exclude some new negatives.
- Changed the console regex to simplify the repetition in it. Does the same thing, but is two lines instead.
- Turned `CreateAutoReplyRegex` back into a function so it can run in a static context without Discord.

Negatives:
```
that what is this one :joy:
behind me is free space
how do i get shredder
Just wondering, tried looking on google but couldn't find answers.  How do I do separate saves of co-op / single player games instead of it overwriting my old progress.
As you all saw in the above here is the candle we stuck on top! This is available in the Questing Update Mod for a limited time Only 7 Days! so make sure to check it out while you still can! All Tier 1 Coal Modules put on the roof of the building will have this shiny candle! Happy Birthday Volcanoids!
```