### PR TITLE
Add const in index.js to enable/disable database use. Also make login token (env var) use clearer.

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -1,4 +1,4 @@
-module.exports = (client) => {
+module.exports = (client, useDatabase) => {
     const Discord = require('discord.js');
     const times = x => f => {
         if (x > 0) {
@@ -82,11 +82,13 @@ module.exports = (client) => {
             return "Now";
     }
 
-    client.connect = (con) => {
-        con.connect(function (err) {
-            if (err) throw err
-            console.log(`Connected to sql database`);
-        });
+    if (useDatabase) {
+        client.connect = (con) => {
+            con.connect(function (err) {
+                if (err) throw err
+                console.log(`Connected to sql database`);
+            });
+        }
     }
 
     /**

--- a/messageEvents/xp.js
+++ b/messageEvents/xp.js
@@ -1,6 +1,8 @@
 let cooldown = new Set();
 
-module.exports.run = async (client, message, isTesting, command, prefix, permlvl, con, table, GSTable) => {
+module.exports.run = async (client, message, isTesting, command, prefix, permlvl, con, table, GSTable, useDatabase) => {
+    if (!useDatabase) return;
+
     //xp
     let msg = message.content.toUpperCase();
 


### PR DESCRIPTION
Doing this as a separate PR from the auto-reply stuff in case you don't want it.

- Moves `process.env[token]` to the top of index.js. This is so we can check to make sure cap/cog is set (whichever we're using) and print an error telling the user to set it if it isn't. `Error: No login token set. Please set '${token}' to a valid token.`
- Adds `const useDatabase = true;`. Also the top of index.js. Defaults to `true`.
This one lets me run the cog bot without dealing with XP, or other database related stuff without an actual database.
It probably doesn't cover everything, but it's good enough to test regex with.